### PR TITLE
web支持容器内部ip显示 https://github.com/sofastack/sofa-dashboard/issues/50

### DIFF
--- a/sofa-dashboard-backend/sofa-dashboard-web/src/main/java/com/alipay/sofa/dashboard/model/InstanceRecord.java
+++ b/sofa-dashboard-backend/sofa-dashboard-web/src/main/java/com/alipay/sofa/dashboard/model/InstanceRecord.java
@@ -25,29 +25,30 @@ import com.alipay.sofa.dashboard.utils.HostPortUtils;
  */
 public class InstanceRecord extends Application {
 
-    public InstanceRecord() {
-    }
+	public InstanceRecord() {
+	}
 
-    public InstanceRecord(Application other) {
-        setAppName(other.getAppName());
-        setHostName(other.getHostName());
-        setPort(other.getPort());
-        setAppState(other.getAppState());
-        setStartTime(other.getStartTime());
-        setLastRecover(other.getLastRecover());
-    }
+	public InstanceRecord(Application other) {
+		setAppName(other.getAppName());
+		setHostName(other.getHostName());
+		setInternalHost(other.getInternalHost());
+		setPort(other.getPort());
+		setAppState(other.getAppState());
+		setStartTime(other.getStartTime());
+		setLastRecover(other.getLastRecover());
+	}
 
-    /**
-     * Id 是接口层概念，用来和前端交换一个短的 host&port 描述
-     *
-     * @return 唯一id
-     */
-    public String getId() {
-        return HostPortUtils.uniqueId(new HostAndPort(getHostName(), getPort()));
-    }
+	/**
+	 * Id 是接口层概念，用来和前端交换一个短的 host&port 描述
+	 *
+	 * @return 唯一id
+	 */
+	public String getId() {
+		return HostPortUtils.uniqueId(new HostAndPort(getHostName(), getInternalHost(), getPort()));
+	}
 
-    public void setId(String instanceId) {
-        // Do nothing for json serializer
-    }
+	public void setId(String instanceId) {
+		// Do nothing for json serializer
+	}
 
 }

--- a/sofa-dashboard-backend/sofa-dashboard-web/src/main/java/com/alipay/sofa/dashboard/utils/HostPortUtils.java
+++ b/sofa-dashboard-backend/sofa-dashboard-web/src/main/java/com/alipay/sofa/dashboard/utils/HostPortUtils.java
@@ -16,11 +16,12 @@
  */
 package com.alipay.sofa.dashboard.utils;
 
-import com.alipay.sofa.dashboard.client.model.common.HostAndPort;
-import org.springframework.util.StringUtils;
-
 import java.util.StringJoiner;
 import java.util.regex.Pattern;
+
+import org.springframework.util.StringUtils;
+
+import com.alipay.sofa.dashboard.client.model.common.HostAndPort;
 
 /**
  * 实例地址id映射工具类
@@ -29,123 +30,142 @@ import java.util.regex.Pattern;
  */
 public final class HostPortUtils {
 
-    /**
-     * 0~255
-     */
-    private static final String  SEGMENT_REG = "((2[0-4]\\d)|(25[0-5])|(1\\d{2})|([1-9]\\d)|(\\d))";
+	/**
+	 * 0~255
+	 */
+	private static final String SEGMENT_REG = "((2[0-4]\\d)|(25[0-5])|(1\\d{2})|([1-9]\\d)|(\\d))";
 
-    private static final Pattern IP_PATTERN  = getIpv4Reg();
+	private static final Pattern IP_PATTERN = getIpv4Reg();
 
-    /**
-     * 工具类隐藏构造方法
-     */
-    private HostPortUtils() {
-    }
+	/**
+	 * 工具类隐藏构造方法
+	 */
+	private HostPortUtils() {
+	}
 
-    /**
-     * 根据 Host and port 获取唯一id
-     *
-     * @param hostAndPort 地址
-     * @return 唯一id
-     */
-    public static String uniqueId(HostAndPort hostAndPort) {
-        long ipSeg = toDigital(hostAndPort.getHost());
-        long portSeg = ((long) hostAndPort.getPort() & 0xFFFF) << Integer.SIZE;
-        return Long.toHexString(portSeg + ipSeg);
-    }
+	/**
+	 * 根据 Host and port 获取唯一id
+	 *
+	 * @param hostAndPort
+	 *            地址
+	 * @return 唯一id：（真实IP+内部IP）编码 & 端口编码
+	 */
+	public static String uniqueId(HostAndPort hostAndPort) {
+		long ipSeg = toDigital(hostAndPort.getHost(), 0);
+		long portSeg = ((long) hostAndPort.getPort() & 0xFFFF);
+		String internalHost = hostAndPort.getInternalHost();
+		if (StringUtils.isEmpty(internalHost) == false) {
+			long internalIpSeg = toDigital(internalHost, 1);
+			return Long.toHexString(ipSeg + internalIpSeg) + "&" + Long.toHexString(portSeg);
+		} else {
+			return Long.toHexString(ipSeg) + "&" + Long.toHexString(portSeg);
+		}
+	}
 
-    /**
-     * 从id中获取ipv4地址
-     *
-     * @param uniqueId 唯一id
-     * @return ipv4地址
-     */
-    public static HostAndPort getById(String uniqueId) {
-        long id = Long.parseLong(uniqueId, 16);
-        long ipSeg = id & 0xFFFFFFFFL;
+	/**
+	 * 从id中获取ipv4地址
+	 *
+	 * @param uniqueId
+	 *            唯一id
+	 * @return ipv4地址
+	 */
+	public static HostAndPort getById(String uniqueId) {
+		String[] segment = uniqueId.split("&");
+		int port = ((Number) (Long.parseLong(segment[1], 16) & 0xFFFF)).intValue();
+		long ipPartSeg = Long.parseLong(segment[0], 16);
+		String ipv4 = fromDigital(ipPartSeg & 0xFFFFFFFFL);
+		long virtualPart = ipPartSeg >> 32;
+		if (virtualPart <= 0) {
+			return new HostAndPort(ipv4, null, port);
+		} else {
+			String virtualIp = fromDigital(virtualPart & 0xFFFFFFFFL);
+			return new HostAndPort(ipv4, virtualIp, port);
+		}
+	}
 
-        String ipv4 = fromDigital(ipSeg);
-        int port = ((Number) ((id >> Integer.SIZE) & 0xFFFF)).intValue();
-        return new HostAndPort(ipv4, port);
-    }
+	/**
+	 * ipv4正则
+	 *
+	 * @return 正则对象
+	 */
+	private static Pattern getIpv4Reg() {
+		StringJoiner sj = new StringJoiner("\\.");
+		sj.add(SEGMENT_REG);
+		sj.add(SEGMENT_REG);
+		sj.add(SEGMENT_REG);
+		sj.add(SEGMENT_REG);
+		return Pattern.compile(sj.toString());
+	}
 
-    /**
-     * ipv4正则
-     *
-     * @return 正则对象
-     */
-    private static Pattern getIpv4Reg() {
-        StringJoiner sj = new StringJoiner("\\.");
-        sj.add(SEGMENT_REG);
-        sj.add(SEGMENT_REG);
-        sj.add(SEGMENT_REG);
-        sj.add(SEGMENT_REG);
-        return Pattern.compile(sj.toString());
-    }
+	/**
+	 * 非法ipv4抛异常
+	 *
+	 * @param ipv4
+	 *            ipv4
+	 */
+	private static void checkIPv4(String ipv4) {
+		if (!isLegalV4(ipv4)) {
+			throw new IllegalArgumentException("Illegal ipv4 value " + ipv4);
+		}
+	}
 
-    /**
-     * 非法ipv4抛异常
-     *
-     * @param ipv4 ipv4
-     */
-    private static void checkIPv4(String ipv4) {
-        if (!isLegalV4(ipv4)) {
-            throw new IllegalArgumentException("Illegal ipv4 value " + ipv4);
-        }
-    }
+	/**
+	 * ip转换为对应32bit数字
+	 *
+	 * @param ipv4
+	 *            点分十进制ipv4
+	 * @param segmentPart
+	 *            TODO
+	 * @return ipv4 对应数字
+	 */
+	private static long toDigital(String ipv4, int segmentPart) {
+		checkIPv4(ipv4);
+		String[] segments = ipv4.split("\\.");
+		long result = 0;
+		for (int i = 0; i < 4; i++) {
+			result += Long.parseLong(segments[3 - i]) << ((8 * i) + segmentPart * Integer.SIZE);
+		}
+		return result;
+	}
 
-    /**
-     * ip转换为对应32bit数字
-     *
-     * @param ipv4 点分十进制ipv4
-     * @return ipv4 对应数字
-     */
-    private static long toDigital(String ipv4) {
-        checkIPv4(ipv4);
-        String[] segments = ipv4.split("\\.");
-        long result = 0;
-        for (int i = 0; i < 4; i++) {
-            result += Long.parseLong(segments[3 - i]) << (8 * i);
-        }
-        return result;
-    }
+	/**
+	 * 检查是否合法ipv4
+	 *
+	 * @param ipv4
+	 *            ipv4地址
+	 * @return 是否匹配
+	 */
+	private static boolean isLegalV4(String ipv4) {
+		return !StringUtils.isEmpty(ipv4) && IP_PATTERN.matcher(ipv4).matches();
+	}
 
-    /**
-     * 检查是否合法ipv4
-     *
-     * @param ipv4 ipv4地址
-     * @return 是否匹配
-     */
-    private static boolean isLegalV4(String ipv4) {
-        return !StringUtils.isEmpty(ipv4) && IP_PATTERN.matcher(ipv4).matches();
-    }
+	/**
+	 * 数字转换为string ip格式
+	 *
+	 * @param ipv4
+	 *            32位数字ip
+	 * @return 点分十进制ip
+	 */
+	public static String fromDigital(Long ipv4) {
+		if (ipv4 > 0xFFFFFFFFL || ipv4 < 0) {
+			throw new IllegalArgumentException("Illegal ipv4 digital " + ipv4);
+		}
+		int[] segments = new int[4];
+		for (int i = 0; i < 4; i++) {
+			segments[3 - i] = ipv4.intValue() & 0xFF;
+			ipv4 >>= 8;
+		}
+		StringJoiner sj = new StringJoiner(".");
+		for (int segment : segments) {
+			sj.add(String.valueOf(segment));
+		}
+		return sj.toString();
+	}
 
-    /**
-     * 数字转换为string ip格式
-     *
-     * @param ipv4 32位数字ip
-     * @return 点分十进制ip
-     */
-    private static String fromDigital(Long ipv4) {
-        if (ipv4 > 0xFFFFFFFFL || ipv4 < 0) {
-            throw new IllegalArgumentException("Illegal ipv4 digital " + ipv4);
-        }
-        int[] segments = new int[4];
-        for (int i = 0; i < 4; i++) {
-            segments[3 - i] = ipv4.intValue() & 0xFF;
-            ipv4 >>= 8;
-        }
-        StringJoiner sj = new StringJoiner(".");
-        for (int segment : segments) {
-            sj.add(String.valueOf(segment));
-        }
-        return sj.toString();
-    }
-
-    public static void main(String[] args) {
-        String id = uniqueId(new HostAndPort("192.168.0.104", 38081));
-        System.out.println(id);
-        HostAndPort hostAndPort = getById(id);
-        System.out.println(hostAndPort);
-    }
+	public static void main(String[] args) {
+		String id = uniqueId(new HostAndPort("192.168.0.104", "8.16.32.64", 38081));
+		System.out.println(id);
+		HostAndPort hostAndPort = getById(id);
+		System.out.println(hostAndPort);
+	}
 }

--- a/sofa-dashboard-backend/sofa-dashboard-web/src/main/resources/application-localhost.properties
+++ b/sofa-dashboard-backend/sofa-dashboard-web/src/main/resources/application-localhost.properties
@@ -1,10 +1,21 @@
-# ark 管控端配置中心地址
-# mysql 数据库连接属性配置
-spring.datasource.url=jdbc:mysql://127.0.0.1:3306/SofaDashboardDB
+## ark 管控端配置中心地址
+## mysql 数据库连接属性配置
+#spring.datasource.url=jdbc:mysql://127.0.0.1:3306/SofaDashboardDB
+#spring.datasource.username=root
+#spring.datasource.password=123456
+## zookeeper 注册中心地址
+#com.alipay.sofa.dashboard.registry=zookeeper://127.0.0.1:2181
+#com.alipay.sofa.dashboard.redis.host=127.0.0.1
+#com.alipay.sofa.dashboard.redis.port=6379
+#com.alipay.sofa.dashboard.zookeeper.address=127.0.0.1:2181
+
+# ark \u7BA1\u63A7\u7AEF\u914D\u7F6E\u4E2D\u5FC3\u5730\u5740
+# mysql \u6570\u636E\u5E93\u8FDE\u63A5\u5C5E\u6027\u914D\u7F6E
+spring.datasource.url=jdbc:mysql://172.23.117.147/dashboard
 spring.datasource.username=root
-spring.datasource.password=123456
-# zookeeper 注册中心地址
-com.alipay.sofa.dashboard.registry=zookeeper://127.0.0.1:2181
-com.alipay.sofa.dashboard.redis.host=127.0.0.1
+spring.datasource.password=root
+# zookeeper \u6CE8\u518C\u4E2D\u5FC3\u5730\u5740
+com.alipay.sofa.dashboard.registry=zookeeper://172.23.117.148:2181
+com.alipay.sofa.dashboard.redis.host=10.23.114.71
 com.alipay.sofa.dashboard.redis.port=6379
-com.alipay.sofa.dashboard.zookeeper.address=127.0.0.1:2181
+com.alipay.sofa.dashboard.zookeeper.address=172.23.117.148:2181

--- a/sofa-dashboard-backend/sofa-dashboard-web/src/main/resources/application-localhost.properties
+++ b/sofa-dashboard-backend/sofa-dashboard-web/src/main/resources/application-localhost.properties
@@ -1,21 +1,10 @@
 ## ark 管控端配置中心地址
 ## mysql 数据库连接属性配置
-#spring.datasource.url=jdbc:mysql://127.0.0.1:3306/SofaDashboardDB
-#spring.datasource.username=root
-#spring.datasource.password=123456
-## zookeeper 注册中心地址
-#com.alipay.sofa.dashboard.registry=zookeeper://127.0.0.1:2181
-#com.alipay.sofa.dashboard.redis.host=127.0.0.1
-#com.alipay.sofa.dashboard.redis.port=6379
-#com.alipay.sofa.dashboard.zookeeper.address=127.0.0.1:2181
-
-# ark \u7BA1\u63A7\u7AEF\u914D\u7F6E\u4E2D\u5FC3\u5730\u5740
-# mysql \u6570\u636E\u5E93\u8FDE\u63A5\u5C5E\u6027\u914D\u7F6E
-spring.datasource.url=jdbc:mysql://172.23.117.147/dashboard
+spring.datasource.url=jdbc:mysql://127.0.0.1:3306/SofaDashboardDB
 spring.datasource.username=root
-spring.datasource.password=root
-# zookeeper \u6CE8\u518C\u4E2D\u5FC3\u5730\u5740
-com.alipay.sofa.dashboard.registry=zookeeper://172.23.117.148:2181
-com.alipay.sofa.dashboard.redis.host=10.23.114.71
+spring.datasource.password=123456
+## zookeeper 注册中心地址
+com.alipay.sofa.dashboard.registry=zookeeper://127.0.0.1:2181
+com.alipay.sofa.dashboard.redis.host=127.0.0.1
 com.alipay.sofa.dashboard.redis.port=6379
-com.alipay.sofa.dashboard.zookeeper.address=172.23.117.148:2181
+com.alipay.sofa.dashboard.zookeeper.address=127.0.0.1:2181

--- a/sofa-dashboard-front/src/pages/Instance/index.jsx
+++ b/sofa-dashboard-front/src/pages/Instance/index.jsx
@@ -62,6 +62,11 @@ class Instance extends React.Component {
         key: 'hostName',
       },
       {
+        title: '内部IP',
+        dataIndex: 'internalHost',
+        key: 'internalHost',
+      },
+      {
         title: '端口',
         dataIndex: 'port',
         key: 'port',


### PR DESCRIPTION
Issue来源：https://github.com/sofastack/sofa-dashboard/issues/50
支持对容器内的服务进行统计，修改如下：
【sofa-dashboard-client已提交pr】

- 应用列表：正确统计容器内服务数量
- 实例列表：支持显示传入的PodIp，增强对k8s下同物理地址、同端口但不同pod的服务统计支持
- redis存储目录修改为：HostIp_内部Ip_端口_维度名称